### PR TITLE
Feat/clear commands

### DIFF
--- a/src/__tests__/xml.spec.ts
+++ b/src/__tests__/xml.spec.ts
@@ -24,6 +24,27 @@ let entryListXML = `<entry name="program">
   </entry>
 </entry>`
 
+let executionGroupsXML = `<entry name="execution_groups">
+  <entry allocate="false" name="OVL">
+    <entry>
+      <entry name="viz">background_d</entry>
+    </entry>
+    <entry>
+      <entry name="viz">background_e</entry>
+    </entry>
+  </entry>
+  <entry allocate="false" name="FULL">
+    <entry>
+      <entry name="viz">background_d</entry>
+    </entry>
+  </entry>
+  <entry allocate="false" name="WALL">
+    <entry name="entry#2">
+      <entry name="viz">background_f</entry>
+    </entry>
+  </entry>
+</entry>`
+
 describe('Roundtrip XML', () => {
 
 	test('Roundtrip a VizEngine entry', async () => {
@@ -38,6 +59,13 @@ describe('Roundtrip XML', () => {
 		let flat = await flattenEntry(fromXML.entry)
 		let fat = entry2XML(flat)
 		expect(buildXML(fat)).toBe(entryListXML)
+	})
+
+	test('Roundtrip Execution Groups', async () => {
+		let fromXML = await Xml2JS.parseStringPromise(executionGroupsXML)
+		let flat = await flattenEntry(fromXML.entry)
+		let fat = entry2XML(flat)
+		expect(buildXML(fat)).toBe(executionGroupsXML)
 	})
 })
 

--- a/src/mse.ts
+++ b/src/mse.ts
@@ -77,7 +77,7 @@ export class MSERep extends EventEmitter implements MSE {
 	async getEngines (): Promise<VizEngine[]> {
 		await this.checkConnection()
 		let handlers = await this.pep.getJS('/scheduler')
-		let vizEntries: AtomEntry[] = (handlers.js as any).scheduler.handler
+		let vizEntries: AtomEntry[] = (handlers.js as any).entry.handler
 			.filter((x: any) => x.$.type === 'viz')
 		let viz = await Promise.all(vizEntries.map(x => flattenEntry(x)))
 		return viz as VizEngine[]

--- a/src/v-connection.ts
+++ b/src/v-connection.ts
@@ -294,11 +294,17 @@ export interface VProfile extends FlatEntry {
 	// TODO add other profile details
 	// handlers
 	// playlist_state
-	// execution_groups
+	execution_groups: {
+		[group: string]: VExecutionGroup
+	}
 	// cursorstate
 	// cursors - element - gui
 	// program - vix - video
 	// directory
+}
+
+export interface VExecutionGroup extends FlatEntry {
+	allocate?: string
 }
 
 /**

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -54,16 +54,20 @@ export async function flattenEntry (x: AtomEntry): Promise<FlatEntry> {
 	if (x.entry && Array.isArray(x.entry)) {
 		for (let e of x.entry) {
 			if (typeof e === 'object') {
-				if (e.$.name === 'model_xml') {
-					try {
-						y[e.$.name] = e._ ? await Xml2JS.parseStringPromise(e._) : ''
-					} catch (err) {
-						y[e.$.name] = e._
+				if (e.$) {
+					if (e.$.name === 'model_xml') {
+						try {
+							y[e.$.name] = e._ ? await Xml2JS.parseStringPromise(e._) : ''
+						} catch (err) {
+							y[e.$.name] = e._
+						}
+					} else {
+						y[e.$.name] = await flattenEntry(e)
 					}
+					delete y[e.$.name].name
 				} else {
-					y[e.$.name] = await flattenEntry(e)
+					y.entry = await flattenEntry(e)
 				}
-				delete y[e.$.name].name
 			} else {
 				if (!y.value) { y = { value: [] } }
 				y.value.push(e)


### PR DESCRIPTION
This PR fixes issues encountered when parsing and flattening output from MSE in version 2.0.1, in order to make the feature to send clear-all commands to Viz Engines possible to implement.

1. Some entries (e.g. in profile's `execution_groups`) have no `name` property. Solved by making them flattened under the temporary name `_entry#N`, which is removed when converting back to XML.
2. The top level node in /scheduler is called _entry_, not _scheduler_, - fixed.
3. `execution_groups` are added to the `VProfile` interface.