### PR TITLE
fix: prevent duplicate external elements

### DIFF
--- a/src/__tests__/peptalk.spec.ts
+++ b/src/__tests__/peptalk.spec.ts
@@ -62,7 +62,20 @@ describe('PepTalk happy', () => {
 						ws.send(`${value.slice(13, 14)}\r\n`)
 						return ws.send(`${value.slice(14)}\r\n`)
 					}
-					return ws.send(`${index} ok <entry depth="${depth}" name="${name}"/>`)
+					if (bits[2] === '4' || bits[2] === '5' || bits[2] === '6') {
+						return
+					}
+					if (bits[2] === '7') {
+						const value = (id: number) => `<entry depth="${depth}" name="${name}">${id}</entry>`
+						ws.send(
+							`${+index - 3} ok {${value(4).length}}${value(4)}\r\n${+index - 2} ok {${value(5).length}}${value(
+								5
+							)}\r\n${+index - 1} ok {${value(6).length}}${value(6).slice(0, 13)}`
+						)
+						ws.send(`${value(6).slice(13)}\r\n`)
+						return ws.send(`${index} ok {${value(7).length}}${value(7)}\r\n`)
+					}
+					return ws.send(`${index} ok <entry depth="${depth}" name="${name}"/>\r\n`)
 				}
 				if (message.indexOf('copy') >= 0) {
 					let destination = message.slice(message.lastIndexOf('/') + 1)
@@ -169,6 +182,31 @@ describe('PepTalk happy', () => {
 			sent: 'get {24}/multithree/with/lines/3 7',
 			status: 'ok',
 		})
+	})
+
+	test('Multi chunk', async () => {
+		await Promise.all([
+			expect(pep.get('/multithree/with/lines/4', 7)).resolves.toMatchObject({
+				body: '<entry depth="7" name="multithree">4</entry>',
+				sent: 'get {24}/multithree/with/lines/4 7',
+				status: 'ok',
+			}),
+			expect(pep.get('/multithree/with/lines/5', 7)).resolves.toMatchObject({
+				body: '<entry depth="7" name="multithree">5</entry>',
+				sent: 'get {24}/multithree/with/lines/5 7',
+				status: 'ok',
+			}),
+			expect(pep.get('/multithree/with/lines/6', 7)).resolves.toMatchObject({
+				body: '<entry depth="7" name="multithree">6</entry>',
+				sent: 'get {24}/multithree/with/lines/6 7',
+				status: 'ok',
+			}),
+			expect(pep.get('/multithree/with/lines/7', 7)).resolves.toMatchObject({
+				body: '<entry depth="7" name="multithree">7</entry>',
+				sent: 'get {24}/multithree/with/lines/7 7',
+				status: 'ok',
+			}),
+		])
 	})
 
 	test('Copy', async () => {

--- a/src/peptalk.ts
+++ b/src/peptalk.ts
@@ -373,7 +373,7 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 		this.port = port ? port : 8595
 	}
 
-	private processMessage(m: string): void {
+	private processChunk(m: string): void {
 		let split = m.trim().split('\r\n')
 		if (split.length === 0) return
 		const re = /\{(\d+)\}/g
@@ -406,6 +406,7 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 				return
 			}
 		}
+		this.leftovers = leftovers ? leftovers : this.leftovers
 		if (split.length > 1) {
 			for (const sm of split) {
 				// console.log('smsm >>>', sm)
@@ -413,9 +414,12 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 			}
 			return
 		}
-		this.leftovers = leftovers ? leftovers : this.leftovers
 		if (split.length === 0) return
 		m = split[0]
+		this.processMessage(m)
+	}
+
+	private processMessage(m: string): void {
 		const firstSpace = m.indexOf(' ')
 		if (firstSpace <= 0) return
 		const c = +m.slice(0, firstSpace)
@@ -538,7 +542,7 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 			// console.log('<<<', `ws://${this.hostname}:${this.port}/`)
 			const ws = new websocket(`ws://${this.hostname}:${this.port}/`)
 			ws.once('open', () => {
-				ws.on('message', this.processMessage.bind(this))
+				ws.on('message', this.processChunk.bind(this))
 				resolve(ws)
 			})
 			ws.once('error', (err) => {

--- a/src/peptalk.ts
+++ b/src/peptalk.ts
@@ -374,7 +374,7 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 	}
 
 	private processChunk(m: string): void {
-		let split = m.trim().split('\r\n')
+		let split = m.replace(/^\r\n|\r\n$/g, '').split('\r\n')
 		if (split.length === 0) return
 		const re = /\{(\d+)\}/g
 		const last = split[split.length - 1]

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -22,6 +22,7 @@ export class Rundown implements VRundown {
 	}
 	private msehttp: HttpMSEClient
 	private channelMap: { [vcpid: number]: ExternalElementInfo } = {}
+	private initialChannelMapPromise: Promise<any>
 
 	constructor(mseRep: MSERep, show: string, profile: string, playlist: string, description: string) {
 		this.mse = mseRep
@@ -46,7 +47,9 @@ export class Rundown implements VRundown {
 			this.mse.resthost ? this.mse.resthost : this.mse.hostname,
 			this.mse.restPort
 		)
-		this.buildChannelMap().catch((err) => console.error(`Warning: Failed to build channel map: ${err.message}`))
+		this.initialChannelMapPromise = this.buildChannelMap().catch((err) =>
+			console.error(`Warning: Failed to build channel map: ${err.message}`)
+		)
 	}
 
 	private async buildChannelMap(vcpid?: number): Promise<boolean> {
@@ -83,7 +86,7 @@ export class Rundown implements VRundown {
 	}
 
 	private ref(id: number): string {
-		return this.channelMap[id].refName ? this.channelMap[id].refName.replace('#', '%23') : 'ref'
+		return this.channelMap[id]?.refName ? this.channelMap[id].refName.replace('#', '%23') : 'ref'
 	}
 
 	async listTemplates(): Promise<string[]> {
@@ -176,6 +179,11 @@ ${entries}
 			} as InternalElement
 		}
 		if (typeof nameOrID === 'number') {
+			try {
+				await this.initialChannelMapPromise
+			} catch (err) {
+				console.error(`Warning: createElement: Channel map not built: ${err.message}`)
+			}
 			try {
 				await this.getElement(nameOrID, elementNameOrChannel)
 				throw new Error(`An external graphics element with name '${nameOrID}' already exists.`)
@@ -388,7 +396,7 @@ ${entries}
 			} else {
 				element.vcpid = elementName.toString()
 				element.channel = element.viz_program
-				element.name = this.ref(elementName)
+				element.name = elementKey && elementKey !== '0' ? elementKey.replace('#', '%23') : 'ref'
 				return element as ExternalElement
 			}
 		} else {


### PR DESCRIPTION
- Check if an element with the same id (and viz_program) already exists
- Fix edge case bugs in response processing (due to faulty concatenation and trimming) causing some responses to be lost and leading to duplicates creation
- Fix initial channel map having invalid refs, rendering already existing elements impossible to take etc.

How we assign IDs to external elements might need rethinking and refactoring, as elements with the same vcpid can exist multiple times with different viz_program (channels)