### PR TITLE
fix: handle both possible scheduler top level node names

### DIFF
--- a/src/mse.ts
+++ b/src/mse.ts
@@ -111,7 +111,10 @@ export class MSERep extends EventEmitter implements MSE {
 	async getEngines(): Promise<VizEngine[]> {
 		await this.checkConnection()
 		const handlers = await this.pep.getJS('/scheduler')
-		const vizEntries: AtomEntry[] = (handlers.js as any).entry.handler.filter((x: any) => x.$.type === 'viz')
+		const handlersBody = handlers.js as any
+		const vizEntries: AtomEntry[] = (handlersBody.entry || handlersBody.scheduler).handler.filter(
+			(x: any) => x.$.type === 'viz'
+		)
 		const viz = await Promise.all(vizEntries.map((x) => flattenEntry(x)))
 		return viz as VizEngine[]
 	}

--- a/src/mse.ts
+++ b/src/mse.ts
@@ -112,6 +112,8 @@ export class MSERep extends EventEmitter implements MSE {
 		await this.checkConnection()
 		const handlers = await this.pep.getJS('/scheduler')
 		const handlersBody = handlers.js as any
+		// Sometimes the main node is is called 'scheduler', sometimes 'entry'
+		// It doesn't seem to depend on specific version, so let's just support both
 		const vizEntries: AtomEntry[] = (handlersBody.entry || handlersBody.scheduler).handler.filter(
 			(x: any) => x.$.type === 'viz'
 		)


### PR DESCRIPTION
Sometimes it is called `scheduler`, sometimes `entry`. 
We're not really sure what this depends on - doesn't seem to be tied to a particular version so it's best to support both.