### PR TITLE
Make the PepTalk test mock the websocket-server

### DIFF
--- a/src/__mocks__/peptalkMock.ts
+++ b/src/__mocks__/peptalkMock.ts
@@ -1,0 +1,107 @@
+import * as Websocket from './ws'
+
+export function setupPeptalkMock(port: number): void {
+	Websocket.mockConstructor((url: string, ws: Websocket) => {
+		// Mock a peptalk server on port 1234:
+		if (url === `ws://localhost:${port}/`) {
+			ws.mockReplyFunction((message: any) => {
+				if (typeof message !== 'string') throw new Error('Mock: message should be a string')
+
+				// console.log('Received', message)
+
+				const index = extractIndex(message)
+				if (message === '1 protocol peptalk\r\n') {
+					return '1 protocol peptalk noevents'
+					// return `${index} protocol peptalk uri`
+				} else if (message.indexOf('close') >= 0) {
+					ws.setTimeout(() => {
+						ws.close()
+					}, 1)
+					return `${index} ok bye`
+				} else if (message.indexOf('get {1}/ 0') >= 0) {
+					return `${index} ok <entry name="pongy"/>\r\n`
+				} else if (message.indexOf('anything goes here') >= 0) {
+					const response = 'responds here'
+					return `${index} ok anything {${response.length}}${response}\r\n`
+				} else if (message.indexOf('special') >= 0) {
+					const response = message.slice(message.indexOf('special') + 8).trim()
+					return `${index} ok special ${response}\r\n`
+				} else if (message.indexOf('get') >= 0) {
+					if (message.match(/mockError/)) {
+						const m = message.match(/mockError\/([^\s]*)/)
+						if (m) {
+							const errorName = m[1]
+							const path = message.slice(message.indexOf('/'), message.lastIndexOf(' '))
+							return `${index} error ${errorName} ${path}\r\n`
+						} else {
+							throw new Error('Peptalk mock: bad request')
+						}
+					}
+
+					const bits = message.match(/\d+\sget\s\{\d+\}\/(\w+)\/with\/lines\/(\d)\s?(\d+)?.*/) as RegExpMatchArray
+					const depth = typeof (bits[3] as string | undefined) === 'string' ? bits[3] : '0'
+					const name = bits[1]
+					if (bits[2] === '2') {
+						const value = `<entry depth="${depth}" name="${name}">something</entry>`
+						return [`${index} ok {${value.length}}${value.slice(0, 13)}\r\n`, `${value.slice(13)}\r\n`]
+					} else if (bits[2] === '3') {
+						const value = `<entry depth="${depth}" name="${name}">something</entry>`
+						return [
+							`${index} ok {${value.length}}${value.slice(0, 13)}\r\n`,
+							`${value.slice(13, 14)}\r\n`,
+							`${value.slice(14)}\r\n`,
+						]
+					} else if (bits[2] === '4' || bits[2] === '5' || bits[2] === '6') {
+						return []
+					} else if (bits[2] === '7') {
+						const value = (id: number) => `<entry depth="${depth}" name="${name}">${id}</entry>`
+						return [
+							`${+index - 3} ok {${value(4).length}}${value(4)}\r\n${+index - 2} ok {${value(5).length}}${value(
+								5
+							)}\r\n${+index - 1} ok {${value(6).length}}${value(6).slice(0, 13)}`,
+							`${value(6).slice(13)}\r\n`,
+							`${index} ok {${value(7).length}}${value(7)}\r\n`,
+						]
+					} else {
+						return `${index} ok <entry depth="${depth}" name="${name}"/>\r\n`
+					}
+				} else if (message.indexOf('copy') >= 0) {
+					let destination = message.slice(message.lastIndexOf('/') + 1)
+					destination = destination.slice(0, destination.indexOf(' '))
+					return `${index} ok ${destination}\r\n`
+				} else if (message.indexOf('delete') >= 0) {
+					// let endOfLife = message.slice(message.lastIndexOf('/') + 1).trim()
+					return `${index} ok\r\n`
+				} else if (message.indexOf('ensure-path') >= 0) {
+					return `${index} ok\r\n`
+				} else if (message.indexOf('insert') >= 0) {
+					const nameMatch = message.match(/name="(\w+)"/) as RegExpMatchArray
+					return `${index} ok ${nameMatch[1]}#2\r\n`
+				} else if (message.indexOf('move') >= 0) {
+					const destMatch = message.match(/\/move\/to\/(\w+)\s/) as RegExpMatchArray
+					return `${index} ok ${destMatch[1]}#2`
+				} else if (message.indexOf('protocol') >= 0) {
+					return `${index} protocol noevents uri peptalk treetalk`
+				} else if (message.indexOf('reinitialize') >= 0) {
+					return `${index} ok`
+				} else if (message.indexOf('replace') >= 0) {
+					const nameMatch = message.match(/name="(\w+)"/) as RegExpMatchArray
+					return `${index} ok ${nameMatch[1]}#2\r\n`
+				} else if (message.indexOf('set text') >= 0) {
+					return [`${index} begin`, `* ${message.slice(message.indexOf(' ') + 1)}`, `${index} ok\r\n`]
+				} else if (message.indexOf('set attribute') >= 0) {
+					return [`${index} begin`, `* ${message.slice(message.indexOf(' ') + 1)}`, `${index} ok 42\r\n`]
+				} else if (message.indexOf('uri ') >= 0) {
+					return `${index} ok http://localhost:8594/element_collection/storage/my/home/in/pep`
+				}
+				return `${index} error unspecified`
+			})
+			ws.mockSetConnected(true)
+		}
+	})
+}
+
+function extractIndex(s: string): string {
+	const firstSpace = s.indexOf(' ')
+	return firstSpace > 0 ? s.slice(0, firstSpace) : ''
+}

--- a/src/__mocks__/ws.ts
+++ b/src/__mocks__/ws.ts
@@ -1,0 +1,146 @@
+import { EventEmitter } from 'events'
+
+const orgSetTimeout = setTimeout
+
+const instances: Array<WebSocket> = []
+let mockConstructor: (url: string, ws: WebSocket) => void
+
+class WebSocket extends EventEmitter {
+	public CONNECTING = 1
+	public OPEN = 2
+	public CLOSING = 3
+	public CLOSED = 4
+
+	public binaryType = ''
+	public readonly connectURL: string
+
+	private _mockConnected = true
+	private _emittedConnected = false
+	private _hasEmittedConnected = false
+	private _failConnectEmitTimeout = 3000
+	private _replyFunction?: (msg: string) => Promise<string | string[]> | string | string[]
+
+	private _readyState: number = this.CLOSED
+
+	public onerror: ((err: any) => void) | undefined = undefined
+	public onopen: (() => void) | undefined = undefined
+	public onclose: (() => void) | undefined = undefined
+	public onmessage: ((msg: any) => void) | undefined = undefined
+
+	public setTimeout = orgSetTimeout
+	public mockInstanceId: number
+	static mockInstanceId = 0
+
+	constructor(connectURL: string) {
+		super()
+		this.connectURL = connectURL
+
+		this.mockInstanceId = WebSocket.mockInstanceId++
+		instances.push(this)
+
+		if (mockConstructor) {
+			mockConstructor(this.connectURL, this)
+		}
+
+		this._readyState = this.CONNECTING
+
+		orgSetTimeout(() => {
+			if (!this._updateConnectionStatus()) {
+				setTimeout(() => {
+					const error = new Error('Unable to Connect')
+					if (typeof this.onerror === 'function') this.onerror(error)
+					this.emit('error', error)
+				}, this._failConnectEmitTimeout)
+			}
+		}, 1)
+
+		// this.emit('open')
+		// this.emit('message', message)
+		// this.emit('error', error)
+		// this.emit('close')
+	}
+	public static getMockInstances(): WebSocket[] {
+		return instances
+	}
+	public static clearMockInstances(): void {
+		instances.splice(0, 9999)
+	}
+	public static mockConstructor(fcn: (url: string, ws: WebSocket) => void): void {
+		mockConstructor = fcn
+	}
+	public send(message: string | any, callback?: (err?: Error) => void): void {
+		if (this._readyState !== this.OPEN) {
+			if (typeof callback === 'function') callback(new Error('Error, not connected'))
+		} else {
+			if (this._replyFunction) {
+				if (typeof callback === 'function') callback()
+
+				Promise.resolve(this._replyFunction(message))
+					.then(async (replies) => {
+						for (const reply of Array.isArray(replies) ? replies : [replies]) {
+							if (reply) {
+								if (typeof this.onmessage === 'function') this.onmessage(reply)
+								this.emit('message', reply)
+
+								await sleep(1)
+							}
+						}
+					})
+					.catch((err) => {
+						console.error(err)
+						if (typeof this.onerror === 'function') this.onerror(err)
+						this.emit('error', err)
+					})
+			} else {
+				throw new Error('mock ws._replyFunction not set')
+			}
+		}
+	}
+	public get readyState(): number {
+		return this._readyState
+	}
+	public mockReplyFunction(fcn: (msg: string) => Promise<string | string[]> | string | string[]): void {
+		this._replyFunction = fcn
+	}
+	public mockSetConnected(connected: boolean): void {
+		this._mockConnected = connected
+
+		orgSetTimeout(() => {
+			this._updateConnectionStatus()
+		}, 1)
+	}
+	public mockSendMessage(message: string | any): void {
+		if (typeof message !== 'string') message = JSON.stringify(message)
+		this.emit('message', message)
+	}
+	public close(): void {
+		this._readyState = this.CLOSING
+
+		orgSetTimeout(() => {
+			this.mockSetConnected(false)
+		}, 1)
+	}
+	private _updateConnectionStatus(): boolean {
+		if (this._mockConnected !== this._emittedConnected || !this._hasEmittedConnected) {
+			this._emittedConnected = this._mockConnected
+			this._hasEmittedConnected = true
+
+			if (this._mockConnected) {
+				this._readyState = this.OPEN
+				if (typeof this.onopen === 'function') this.onopen()
+				this.emit('open')
+			} else {
+				this._readyState = this.CLOSED
+				if (typeof this.onclose === 'function') this.onclose()
+				this.emit('close')
+			}
+		}
+		return this._mockConnected
+	}
+}
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => orgSetTimeout(resolve, ms))
+}
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace WebSocket {} // eslint-disable-lint
+export = WebSocket


### PR DESCRIPTION
Currently, the unit tests spins up a local websocket-server to pipe data through. This is not ideal in unit tests, since it creates a dependency on a network stack and adds unnessesary complexity.

This PR replaces the websocket client/server with a Mock, so that everything runs internally.
This makes it easier to write future tests, doesn't require a network stack, and should run faster & more reliably.

_(There is still a HTTP-server running for MSE-tests, but I haven't included a fix for that in this PR.)_