### PR TITLE
fix: don't throw away middle chunks

### DIFF
--- a/src/peptalk.ts
+++ b/src/peptalk.ts
@@ -405,9 +405,7 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 					return
 				}
 			} else if (leftovers) {
-				this.leftovers.previous = this.leftovers.previous + leftovers.previous
-				this.leftovers.remaining = leftovers.remaining
-				leftovers = null
+				leftovers.previous = this.leftovers.previous + leftovers.previous
 			}
 		}
 		this.leftovers = leftovers ? leftovers : this.leftovers

--- a/src/peptalk.ts
+++ b/src/peptalk.ts
@@ -395,15 +395,19 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 		}
 		// console.log('SAF >>>', split)
 		if (this.leftovers) {
-			this.leftovers.previous = this.leftovers.previous + split[0]
 			if (Array.isArray(split) && split.length > 0) {
+				this.leftovers.previous = this.leftovers.previous + split[0]
 				this.leftovers.remaining -= Buffer.byteLength(split[0], 'utf8')
-			}
-			if (this.leftovers.remaining <= 0) {
-				split[0] = this.leftovers.previous
-				this.leftovers = null
-			} else {
-				return
+				if (this.leftovers.remaining <= 0) {
+					split[0] = this.leftovers.previous
+					this.leftovers = null
+				} else {
+					return
+				}
+			} else if (leftovers) {
+				this.leftovers.previous = this.leftovers.previous + leftovers.previous
+				this.leftovers.remaining = leftovers.remaining
+				leftovers = null
 			}
 		}
 		this.leftovers = leftovers ? leftovers : this.leftovers


### PR DESCRIPTION
Fixes a bug where middle chunks of messages divided into 3+ chunks were `undefined`, leading to XML parsing errors.