### PR TITLE
feat!: support internal elements in multiple shows

### DIFF
--- a/src/mse.ts
+++ b/src/mse.ts
@@ -6,8 +6,8 @@ import { flattenEntry, AtomEntry, FlatEntry } from './xml'
 import { Rundown } from './rundown'
 import * as uuid from 'uuid'
 
-const uuidRe = /[a-fA-f0-9]{8}-[a-fA-f0-9]{4}-[a-fA-f0-9]{4}-[a-fA-f0-9]{4}-[a-fA-f0-9]{12}/
-export const creatorName = 'Sofie'
+const UUID_RE = /[a-fA-f0-9]{8}-[a-fA-f0-9]{4}-[a-fA-f0-9]{4}-[a-fA-f0-9]{4}-[a-fA-f0-9]{12}/
+export const CREATOR_NAME = 'Sofie'
 
 export class MSERep extends EventEmitter implements MSE {
 	readonly hostname: string
@@ -134,7 +134,7 @@ export class MSERep extends EventEmitter implements MSE {
 		if (!showId.endsWith('}')) {
 			showId = showId + '}'
 		}
-		if (!showId.match(uuidRe)) {
+		if (!showId.match(UUID_RE)) {
 			return Promise.reject(new Error(`Show id must be a UUID and '${showId}' is not.`))
 		}
 		await this.checkConnection()
@@ -163,7 +163,7 @@ export class MSERep extends EventEmitter implements MSE {
 		if (!playlistName.endsWith('}')) {
 			playlistName = playlistName + '}'
 		}
-		if (!playlistName.match(uuidRe)) {
+		if (!playlistName.match(UUID_RE)) {
 			return Promise.reject(new Error(`Playlist name must be a UUID and '${playlistName}' is not.`))
 		}
 		await this.checkConnection()
@@ -204,7 +204,7 @@ export class MSERep extends EventEmitter implements MSE {
 			}
 		}
 		if (!playlistExists) {
-			playlistID = playlistID && playlistID.match(uuidRe) ? playlistID.toUpperCase() : uuid.v4().toUpperCase()
+			playlistID = playlistID && playlistID.match(UUID_RE) ? playlistID.toUpperCase() : uuid.v4().toUpperCase()
 			const modifiedDate = `${date.getUTCDate().toString().padStart(2, '0')}.${(date.getUTCMonth() + 1)
 				.toString()
 				.padStart(2, '0')}.${date.getFullYear()} ${date

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -1,7 +1,18 @@
-import { VRundown, VTemplate, InternalElement, ExternalElement, VElement, ExternalElementId } from './v-connection'
+import {
+	VRundown,
+	VTemplate,
+	InternalElement,
+	ExternalElement,
+	VElement,
+	ExternalElementId,
+	ElementId,
+	isExternalElement,
+	InternalElementId,
+	isInternalElement,
+} from './v-connection'
 import { CommandResult, createHTTPContext, HttpMSEClient, HTTPRequestError } from './msehttp'
 import { InexistentError, LocationType, PepResponse } from './peptalk'
-import { MSERep } from './mse'
+import { MSERep, creatorName } from './mse'
 import { flattenEntry, AtomEntry, FlatEntry } from './xml'
 import * as uuid from 'uuid'
 
@@ -12,7 +23,6 @@ interface ExternalElementInfo {
 }
 
 export class Rundown implements VRundown {
-	readonly show: string
 	readonly playlist: string
 	readonly profile: string
 	readonly description: string
@@ -25,15 +35,8 @@ export class Rundown implements VRundown {
 	private channelMap: { [id: string]: ExternalElementInfo } = {}
 	private initialChannelMapPromise: Promise<any>
 
-	constructor(mseRep: MSERep, show: string, profile: string, playlist: string, description: string) {
+	constructor(mseRep: MSERep, profile: string, playlist: string, description: string) {
 		this.mse = mseRep
-		this.show = show.startsWith('/storage/shows/') ? show.slice(15) : show
-		if (this.show.startsWith('{')) {
-			this.show = this.show.slice(1)
-		}
-		if (this.show.endsWith('}')) {
-			this.show = this.show.slice(0, -1)
-		}
 		this.profile = profile.startsWith('/config/profiles/') ? profile.slice(17) : profile
 		this.playlist = playlist
 		if (this.playlist.startsWith('{')) {
@@ -53,22 +56,22 @@ export class Rundown implements VRundown {
 		)
 	}
 
-	private static makeKey(vcpid: number, channel?: string) {
-		return `${vcpid}_${channel || ''}`
+	private static makeKey(elementId: ExternalElementId) {
+		return `${elementId.vcpid}_${elementId.channel ?? ''}`
 	}
 
-	private async buildChannelMap(vcpid?: number, channel?: string): Promise<boolean> {
-		if (typeof vcpid === 'number') {
-			if (Object.prototype.hasOwnProperty.call(this.channelMap, Rundown.makeKey(vcpid, channel))) {
+	private async buildChannelMap(elementId?: ExternalElementId): Promise<boolean> {
+		if (elementId) {
+			if (Object.prototype.hasOwnProperty.call(this.channelMap, Rundown.makeKey(elementId))) {
 				return true
 			}
 		}
 		await this.mse.checkConnection()
-		const elements = vcpid ? [{ vcpid, channel }] : await this.listElements()
+		const elements = elementId ? [elementId] : await this.listExternalElements()
 		for (const e of elements) {
 			if (typeof e !== 'string') {
-				const element = await this.getElement(e.vcpid, e.channel)
-				this.channelMap[Rundown.makeKey(e.vcpid, e.channel)] = {
+				const element = await this.getElement(e)
+				this.channelMap[Rundown.makeKey(e)] = {
 					vcpid: e.vcpid,
 					channel: element.channel,
 					refName:
@@ -78,13 +81,11 @@ export class Rundown implements VRundown {
 				}
 			}
 		}
-		return typeof vcpid === 'number'
-			? Object.prototype.hasOwnProperty.call(this.channelMap, Rundown.makeKey(vcpid, channel))
-			: false
+		return elementId ? Object.prototype.hasOwnProperty.call(this.channelMap, Rundown.makeKey(elementId)) : false
 	}
 
-	private ref(vcpid: number, channel?: string, unescape = false): string {
-		const key = Rundown.makeKey(vcpid, channel)
+	private ref(elementId: ExternalElementId, unescape = false): string {
+		const key = Rundown.makeKey(elementId)
 		let str = this.channelMap[key]?.refName || 'ref'
 
 		if (unescape) {
@@ -97,16 +98,16 @@ export class Rundown implements VRundown {
 		return str
 	}
 
-	async listTemplates(): Promise<string[]> {
+	async listTemplates(showId: string): Promise<string[]> {
 		await this.mse.checkConnection()
-		const templateList = await this.pep.getJS(`/storage/shows/{${this.show}}/mastertemplates`, 1)
+		const templateList = await this.pep.getJS(`/storage/shows/{${showId}}/mastertemplates`, 1)
 		const flatTemplates = await flattenEntry(templateList.js as AtomEntry)
 		return Object.keys(flatTemplates).filter((x) => x !== 'name')
 	}
 
-	async getTemplate(templateName: string): Promise<VTemplate> {
+	async getTemplate(templateName: string, showId: string): Promise<VTemplate> {
 		await this.mse.checkConnection()
-		const template = await this.pep.getJS(`/storage/shows/{${this.show}}/mastertemplates/${templateName}`)
+		const template = await this.pep.getJS(`/storage/shows/{${showId}}/mastertemplates/${templateName}`)
 		let flatTemplate = await flattenEntry(template.js as AtomEntry)
 		if (Object.keys(flatTemplate).length === 1) {
 			flatTemplate = flatTemplate[Object.keys(flatTemplate)[0]] as FlatEntry
@@ -115,116 +116,133 @@ export class Rundown implements VRundown {
 	}
 
 	async createElement(
+		elementId: InternalElementId,
 		templateName: string,
-		elementName: string,
 		textFields: string[],
 		channel?: string
 	): Promise<InternalElement>
-	async createElement(vcpid: number, channel?: string, alias?: string): Promise<ExternalElement>
+	async createElement(elementId: ExternalElementId): Promise<ExternalElement>
 	async createElement(
-		nameOrID: string | number,
-		elementNameOrChannel?: string,
-		aliasOrTextFields?: string[] | string,
+		elementId: ElementId,
+		templateName?: string,
+		textFields?: string[],
 		channel?: string
 	): Promise<VElement> {
 		// TODO ensure that a playlist is created with sub-element "elements"
-		if (typeof nameOrID === 'string') {
-			try {
-				if (elementNameOrChannel) {
-					await this.getElement(elementNameOrChannel)
-				}
-				throw new Error(`An internal graphics element with name '${elementNameOrChannel}' already exists.`)
-			} catch (err) {
-				if (err.message.startsWith('An internal graphics element')) throw err
-			}
-			const template = await this.getTemplate(nameOrID)
-			// console.dir((template[nameOrID] as any).model_xml.model.schema[0].fielddef, { depth: 10 })
-			let fielddef
-			if (
-				Object.prototype.hasOwnProperty.call(template, 'model_xml') &&
-				typeof template.model_xml === 'object' &&
-				Object.prototype.hasOwnProperty.call(template.model_xml, 'model') &&
-				typeof template.model_xml.model === 'object'
-			) {
-				fielddef = (template as any).model_xml.model.schema[0].fielddef
-			} else {
-				throw new Error(
-					`Could not retrieve field definitions for tempalte '${nameOrID}'. Not creating element '${elementNameOrChannel}'.`
-				)
-			}
-			let fieldNames: string[] = fielddef ? fielddef.map((x: any): string => x.$.name) : []
-			let entries = ''
-			const data: { [name: string]: string } = {}
-			if (Array.isArray(aliasOrTextFields)) {
-				if (aliasOrTextFields.length > fieldNames.length) {
-					throw new Error(
-						`For template '${nameOrID}' with ${fieldNames.length} field(s), ${aliasOrTextFields.length} fields have been provided.`
-					)
-				}
-				fieldNames = fieldNames.sort()
-				for (let x = 0; x < fieldNames.length; x++) {
-					entries += `    <entry name="${fieldNames[x]}">${aliasOrTextFields[x] ? aliasOrTextFields[x] : ''}</entry>\n`
-					data[fieldNames[x]] = aliasOrTextFields[x] ? aliasOrTextFields[x] : ''
-				}
-			}
-			const vizProgram = channel ? ` viz_program="${channel}"` : ''
-			await this.pep.insert(
-				`/storage/shows/{${this.show}}/elements/${elementNameOrChannel}`,
-				`<element name="${elementNameOrChannel}" guid="${uuid.v4()}" updated="${new Date().toISOString()}" creator="Sofie" ${vizProgram}>
-  <ref name="master_template">/storage/shows/{${this.show}}/mastertemplates/${nameOrID}</ref>
-  <entry name="default_alternatives"/>
-  <entry name="data">
-${entries}
-  </entry>
-</element>`,
-				LocationType.Last
-			)
-			return {
-				name: elementNameOrChannel,
-				template: nameOrID,
-				data,
-				channel,
-			} as InternalElement
+		if (isInternalElement(elementId)) {
+			return this.createInternalElement(elementId, templateName as string, textFields as string[], channel)
+		} else {
+			return this.createExternalElement(elementId)
 		}
-		if (typeof nameOrID === 'number') {
-			try {
-				await this.initialChannelMapPromise
-			} catch (err) {
-				console.error(`Warning: createElement: Channel map not built: ${err.message}`)
-			}
-			try {
-				await this.getElement(nameOrID, elementNameOrChannel)
-				throw new Error(`An external graphics element with name '${nameOrID}' already exists.`)
-			} catch (err) {
-				if (err.message.startsWith('An external graphics element')) throw err
-			}
-			const vizProgram = elementNameOrChannel ? ` viz_program="${elementNameOrChannel}"` : ''
-			const { body: path } = await this.pep.insert(
-				`/storage/playlists/{${this.playlist}}/elements/`,
-				`<ref available="0.00" loaded="0.00" take_count="0"${vizProgram}>/external/pilotdb/elements/${nameOrID}</ref>`,
-				LocationType.Last
-			)
-			this.channelMap[Rundown.makeKey(nameOrID, elementNameOrChannel)] = {
-				vcpid: nameOrID,
-				channel: elementNameOrChannel,
-				refName: path ? path.slice(path.lastIndexOf('/') + 1) : 'ref',
-			}
-			return {
-				vcpid: nameOrID.toString(),
-				channel: elementNameOrChannel,
-			} as ExternalElement
-		}
-		throw new Error('Create element called with neither a string or numerical reference.')
 	}
 
-	async listElements(): Promise<Array<string | ExternalElementId>> {
+	async createInternalElement(
+		elementId: InternalElementId,
+		templateName: string,
+		textFields: string[],
+		channel?: string
+	): Promise<InternalElement> {
+		try {
+			await this.getElement(elementId)
+			throw new Error(`An internal graphics element with name '${elementId.name}' already exists.`)
+		} catch (err) {
+			if (err.message.startsWith('An internal graphics element')) throw err
+		}
+		const template = await this.getTemplate(templateName, elementId.showId)
+		// console.dir((template[nameOrID] as any).model_xml.model.schema[0].fielddef, { depth: 10 })
+		let fielddef
+		if (
+			Object.prototype.hasOwnProperty.call(template, 'model_xml') &&
+			typeof template.model_xml === 'object' &&
+			Object.prototype.hasOwnProperty.call(template.model_xml, 'model') &&
+			typeof template.model_xml.model === 'object'
+		) {
+			fielddef = (template as any).model_xml.model.schema[0].fielddef
+		} else {
+			throw new Error(
+				`Could not retrieve field definitions for tempalte '${templateName}'. Not creating element '${elementId.name}'.`
+			)
+		}
+		let fieldNames: string[] = fielddef ? fielddef.map((x: any): string => x.$.name) : []
+		let entries = ''
+		const data: { [name: string]: string } = {}
+		if (textFields.length > fieldNames.length) {
+			throw new Error(
+				`For template '${templateName}' with ${fieldNames.length} field(s), ${textFields.length} fields have been provided.`
+			)
+		}
+		fieldNames = fieldNames.sort()
+		for (let x = 0; x < fieldNames.length; x++) {
+			entries += `    <entry name="${fieldNames[x]}">${textFields[x] ? textFields[x] : ''}</entry>\n`
+			data[fieldNames[x]] = textFields[x] ? textFields[x] : ''
+		}
+		const vizProgram = channel ? ` viz_program="${channel}"` : ''
+		await this.pep.insert(
+			`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`,
+			`<element name="${
+				elementId.name
+			}" guid="${uuid.v4()}" updated="${new Date().toISOString()}" creator="${creatorName}" ${vizProgram}>
+<ref name="master_template">/storage/shows/{${elementId.showId}}/mastertemplates/${templateName}</ref>
+<entry name="default_alternatives"/>
+<entry name="data">
+${entries}
+</entry>
+</element>`,
+			LocationType.Last
+		)
+		return {
+			name: elementId.name,
+			template: templateName,
+			data,
+			channel,
+		}
+	}
+
+	async createExternalElement(elementId: ExternalElementId): Promise<ExternalElement> {
+		try {
+			await this.initialChannelMapPromise
+		} catch (err) {
+			console.error(`Warning: createElement: Channel map not built: ${err.message}`)
+		}
+		try {
+			await this.getElement(elementId)
+			throw new Error(`An external graphics element with name '${elementId.vcpid}' already exists.`)
+		} catch (err) {
+			if (err.message.startsWith('An external graphics element')) throw err
+		}
+		const vizProgram = elementId.channel ? ` viz_program="${elementId.channel}"` : ''
+		const { body: path } = await this.pep.insert(
+			`/storage/playlists/{${this.playlist}}/elements/`,
+			`<ref available="0.00" loaded="0.00" take_count="0"${vizProgram}>/external/pilotdb/elements/${elementId.vcpid}</ref>`,
+			LocationType.Last
+		)
+		this.channelMap[Rundown.makeKey(elementId)] = {
+			vcpid: elementId.vcpid,
+			channel: elementId.channel,
+			refName: path ? path.slice(path.lastIndexOf('/') + 1) : 'ref',
+		}
+		return {
+			vcpid: elementId.vcpid.toString(),
+			channel: elementId.channel,
+		}
+	}
+
+	async listInternalElements(showId: string): Promise<InternalElementId[]> {
 		await this.mse.checkConnection()
-		const [showElementsList, playlistElementsList] = await Promise.all([
-			this.pep.getJS(`/storage/shows/{${this.show}}/elements`, 1),
-			this.pep.getJS(`/storage/playlists/{${this.playlist}}/elements`, 2),
-		])
+		const showElementsList = await this.pep.getJS(`/storage/shows/{${showId}}/elements`, 1)
 		const flatShowElements = await flattenEntry(showElementsList.js as AtomEntry)
-		const elementNames: Array<string | ExternalElementId> = Object.keys(flatShowElements).filter((x) => x !== 'name')
+		const elementNames: Array<InternalElementId> = Object.keys(flatShowElements)
+			.filter((x) => x !== 'name')
+			.map((element) => ({
+				name: element,
+				showId,
+			}))
+		return elementNames
+	}
+
+	async listExternalElements(): Promise<Array<ExternalElementId>> {
+		await this.mse.checkConnection()
+		const playlistElementsList = await this.pep.getJS(`/storage/playlists/{${this.playlist}}/elements`, 2)
 		const flatPlaylistElements: FlatEntry = await flattenEntry(playlistElementsList.js as AtomEntry)
 		const elementsRefs = flatPlaylistElements.elements
 			? Object.keys(flatPlaylistElements.elements as FlatEntry).map((k) => {
@@ -234,24 +252,25 @@ ${entries}
 					return { vcpid: +ref.slice(lastSlash + 1), channel: entry.viz_program as string | undefined }
 			  })
 			: []
-		return elementNames.concat(elementsRefs)
+		return elementsRefs
 	}
 
-	async activate(twice?: boolean, initShow = true, initPlaylist = true): Promise<CommandResult> {
+	async initializeShow(showId: string): Promise<CommandResult> {
+		return this.msehttp.initializeShow(showId)
+	}
+	async cleanupShow(showId: string): Promise<CommandResult> {
+		return this.msehttp.cleanupShow(showId)
+	}
+
+	async activate(twice?: boolean, initPlaylist = true): Promise<CommandResult> {
 		let result: CommandResult = {
 			// Returned when initShow = false and initPlaylist = false
 			path: '/',
 			status: 200,
 			response: 'No commands to run.',
 		}
-		if (twice && initShow) {
-			result = await this.msehttp.initializeShow(this.show)
-		}
 		if (twice && initPlaylist) {
 			result = await this.msehttp.initializePlaylist(this.playlist)
-		}
-		if (initShow) {
-			result = await this.msehttp.initializeShow(this.show)
 		}
 		if (initPlaylist) {
 			result = await this.msehttp.initializePlaylist(this.playlist)
@@ -259,24 +278,17 @@ ${entries}
 		return result
 	}
 
-	async deactivate(cleanupShow = true): Promise<CommandResult> {
-		if (cleanupShow) {
-			await this.msehttp.cleanupShow(this.show)
-		}
+	async deactivate(): Promise<CommandResult> {
 		return this.msehttp.cleanupPlaylist(this.playlist)
 	}
 
-	cleanup(): Promise<CommandResult> {
-		return this.msehttp.cleanupShow(this.show)
-	}
-
-	async deleteElement(elementName: string | number, channel?: string): Promise<PepResponse> {
-		if (typeof elementName === 'string') {
-			return this.pep.delete(`/storage/shows/{${this.show}}/elements/${elementName}`)
+	async deleteElement(elementId: ElementId): Promise<PepResponse> {
+		if (isInternalElement(elementId)) {
+			return this.pep.delete(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
 		} else {
 			// Note: For some reason, in contrast to the other commands, the delete command only works with the path being unescaped:
-			const path = this.getExternalElementPath(elementName, channel, true)
-			if (await this.buildChannelMap(elementName, channel)) {
+			const path = this.getExternalElementPath(elementId, true)
+			if (await this.buildChannelMap(elementId)) {
 				return this.pep.delete(path)
 			} else {
 				throw new InexistentError(-1, path)
@@ -284,16 +296,16 @@ ${entries}
 		}
 	}
 
-	async cue(elementName: string | number, channel?: string): Promise<CommandResult> {
-		if (typeof elementName === 'string') {
-			return this.msehttp.cue(`/storage/shows/{${this.show}}/elements/${elementName}`)
+	async cue(elementId: ElementId): Promise<CommandResult> {
+		if (isInternalElement(elementId)) {
+			return this.msehttp.cue(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
 		} else {
-			const path = this.getExternalElementPath(elementName, channel)
-			if (await this.buildChannelMap(elementName, channel)) {
+			const path = this.getExternalElementPath(elementId)
+			if (await this.buildChannelMap(elementId)) {
 				return this.msehttp.cue(path)
 			} else {
 				throw new HTTPRequestError(
-					`Cannot cue external element as ID '${elementName}' is not known in this rundown.`,
+					`Cannot cue external element as ID '${elementId.vcpid}' is not known in this rundown.`,
 					this.msehttp.baseURL,
 					path
 				)
@@ -301,16 +313,16 @@ ${entries}
 		}
 	}
 
-	async take(elementName: string | number, channel?: string): Promise<CommandResult> {
-		if (typeof elementName === 'string') {
-			return this.msehttp.take(`/storage/shows/{${this.show}}/elements/${elementName}`)
+	async take(elementId: ElementId): Promise<CommandResult> {
+		if (isInternalElement(elementId)) {
+			return this.msehttp.take(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
 		} else {
-			const path = this.getExternalElementPath(elementName, channel)
-			if (await this.buildChannelMap(elementName, channel)) {
+			const path = this.getExternalElementPath(elementId)
+			if (await this.buildChannelMap(elementId)) {
 				return this.msehttp.take(path)
 			} else {
 				throw new HTTPRequestError(
-					`Cannot take external element as ID '${elementName}' is not known in this rundown.`,
+					`Cannot take external element as ID '${elementId.vcpid}' is not known in this rundown.`,
 					this.msehttp.baseURL,
 					path
 				)
@@ -318,16 +330,16 @@ ${entries}
 		}
 	}
 
-	async continue(elementName: string | number, channel?: string): Promise<CommandResult> {
-		if (typeof elementName === 'string') {
-			return this.msehttp.continue(`/storage/shows/{${this.show}}/elements/${elementName}`)
+	async continue(elementId: ElementId): Promise<CommandResult> {
+		if (isInternalElement(elementId)) {
+			return this.msehttp.continue(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
 		} else {
-			const path = this.getExternalElementPath(elementName, channel)
-			if (await this.buildChannelMap(elementName, channel)) {
+			const path = this.getExternalElementPath(elementId)
+			if (await this.buildChannelMap(elementId)) {
 				return this.msehttp.continue(path)
 			} else {
 				throw new HTTPRequestError(
-					`Cannot continue external element as ID '${elementName}' is not known in this rundown.`,
+					`Cannot continue external element as ID '${elementId.vcpid}' is not known in this rundown.`,
 					this.msehttp.baseURL,
 					path
 				)
@@ -335,16 +347,16 @@ ${entries}
 		}
 	}
 
-	async continueReverse(elementName: string | number, channel?: string): Promise<CommandResult> {
-		if (typeof elementName === 'string') {
-			return this.msehttp.continueReverse(`/storage/shows/{${this.show}}/elements/${elementName}`)
+	async continueReverse(elementId: ElementId): Promise<CommandResult> {
+		if (isInternalElement(elementId)) {
+			return this.msehttp.continueReverse(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
 		} else {
-			const path = this.getExternalElementPath(elementName, channel)
-			if (await this.buildChannelMap(elementName, channel)) {
+			const path = this.getExternalElementPath(elementId)
+			if (await this.buildChannelMap(elementId)) {
 				return this.msehttp.continueReverse(path)
 			} else {
 				throw new HTTPRequestError(
-					`Cannot continue reverse external element as ID '${elementName}' is not known in this rundown.`,
+					`Cannot continue reverse external element as ID '${elementId.vcpid}' is not known in this rundown.`,
 					this.msehttp.baseURL,
 					path
 				)
@@ -352,16 +364,16 @@ ${entries}
 		}
 	}
 
-	async out(elementName: string | number, channel?: string): Promise<CommandResult> {
-		if (typeof elementName === 'string') {
-			return this.msehttp.out(`/storage/shows/{${this.show}}/elements/${elementName}`)
+	async out(elementId: ElementId): Promise<CommandResult> {
+		if (isInternalElement(elementId)) {
+			return this.msehttp.out(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
 		} else {
-			const path = this.getExternalElementPath(elementName, channel)
-			if (await this.buildChannelMap(elementName, channel)) {
+			const path = this.getExternalElementPath(elementId)
+			if (await this.buildChannelMap(elementId)) {
 				return this.msehttp.out(path)
 			} else {
 				throw new HTTPRequestError(
-					`Cannot take out external element as ID '${elementName}' is not known in this rundown.`,
+					`Cannot take out external element as ID '${elementId.vcpid}' is not known in this rundown.`,
 					this.msehttp.baseURL,
 					path
 				)
@@ -369,36 +381,45 @@ ${entries}
 		}
 	}
 
-	async initialize(elementName: number, channel?: string): Promise<CommandResult> {
-		const path = this.getExternalElementPath(elementName, channel)
-		if (await this.buildChannelMap(elementName, channel)) {
+	async initialize(elementId: ExternalElementId): Promise<CommandResult> {
+		const path = this.getExternalElementPath(elementId)
+		if (await this.buildChannelMap(elementId)) {
 			return this.msehttp.initialize(path)
 		} else {
 			throw new HTTPRequestError(
-				`Cannot initialize external element as ID '${elementName}' is not known in this rundown.`,
+				`Cannot initialize external element as ID '${elementId.vcpid}' is not known in this rundown.`,
 				this.msehttp.baseURL,
 				path
 			)
 		}
 	}
 
-	async purge(elementsToKeep?: ExternalElementId[]): Promise<PepResponse> {
+	async purge(showIds: string[], elementsToKeep?: ElementId[]): Promise<PepResponse> {
 		// let playlist = await this.mse.getPlaylist(this.playlist)
 		// if (playlist.active_profile.value) {
 		// 	throw new Error(`Cannot purge an active profile.`)
 		// }
-		await this.pep.replace(`/storage/shows/{${this.show}}/elements`, '<elements/>')
+		for (const showId of showIds) {
+			// @todo: don't purge elementsToKeep or elements not created by us
+			await this.pep.replace(`/storage/shows/{${showId}}/elements`, '<elements/>')
+		}
 		if (elementsToKeep && elementsToKeep.length) {
+			const externalElementsToKeep: ExternalElementId[] = []
+			for (const element of elementsToKeep) {
+				if (isExternalElement(element)) {
+					externalElementsToKeep.push(element)
+				}
+			}
 			await this.buildChannelMap()
 			const elementsSet = new Set(
-				elementsToKeep.map((e) => {
-					return Rundown.makeKey(e.vcpid, e.channel)
+				externalElementsToKeep.map((e) => {
+					return Rundown.makeKey(e)
 				})
 			)
 			for (const key in this.channelMap) {
 				if (!elementsSet.has(key)) {
 					try {
-						await this.deleteElement(this.channelMap[key].vcpid, this.channelMap[key].channel)
+						await this.deleteElement(this.channelMap[key])
 					} catch (e) {
 						if (!(e instanceof InexistentError)) {
 							throw e
@@ -412,15 +433,15 @@ ${entries}
 		return { id: '*', status: 'ok' } as PepResponse
 	}
 
-	async getElement(elementName: string | number, channel?: string): Promise<VElement> {
+	async getElement(elementId: ElementId): Promise<VElement> {
 		await this.mse.checkConnection()
-		if (typeof elementName === 'number') {
+		if (isExternalElement(elementId)) {
 			const playlistsList = await this.pep.getJS(`/storage/playlists/{${this.playlist}}/elements`, 2)
 			const flatPlaylistElements: FlatEntry = await flattenEntry(playlistsList.js as AtomEntry)
 			const elementKey = Object.keys(flatPlaylistElements.elements as FlatEntry).find((k) => {
 				const elem = (flatPlaylistElements.elements as FlatEntry)[k] as FlatEntry
 				const ref = elem.value as string
-				return ref.endsWith(`/${elementName}`) && (!channel || elem.viz_program === channel)
+				return ref.endsWith(`/${elementId.vcpid}`) && (!elementId.channel || elem.viz_program === elementId.channel)
 			})
 			const element =
 				typeof elementKey === 'string'
@@ -429,18 +450,18 @@ ${entries}
 			if (!element) {
 				throw new InexistentError(
 					typeof playlistsList.id === 'number' ? playlistsList.id : 0,
-					`/storage/playlists/{${this.playlist}}/elements#${elementName}`
+					`/storage/playlists/{${this.playlist}}/elements#${elementId.vcpid}`
 				)
 			} else {
-				element.vcpid = elementName.toString()
+				element.vcpid = elementId.vcpid.toString()
 				element.channel = element.viz_program
 				element.name = elementKey && elementKey !== '0' ? elementKey.replace('#', '%23') : 'ref'
 				return element as ExternalElement
 			}
 		} else {
-			const element = await this.pep.getJS(`/storage/shows/{${this.show}}/elements/${elementName}`)
-			const flatElement: FlatEntry = (await flattenEntry(element.js as AtomEntry))[elementName] as FlatEntry
-			flatElement.name = elementName
+			const element = await this.pep.getJS(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
+			const flatElement: FlatEntry = (await flattenEntry(element.js as AtomEntry))[elementId.name] as FlatEntry
+			flatElement.name = elementId.name
 			return flatElement as InternalElement
 		}
 	}
@@ -450,7 +471,7 @@ ${entries}
 		return playlist.active_profile && typeof playlist.active_profile.value !== 'undefined'
 	}
 
-	private getExternalElementPath(elementName: number, channel?: string, unescape = false): string {
-		return `/storage/playlists/{${this.playlist}}/elements/${this.ref(elementName, channel, unescape)}`
+	private getExternalElementPath(elementId: ExternalElementId, unescape = false): string {
+		return `/storage/playlists/{${this.playlist}}/elements/${this.ref(elementId, unescape)}`
 	}
 }

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -144,7 +144,7 @@ export class Rundown implements VRundown {
 	): Promise<InternalElement> {
 		try {
 			await this.getElement(elementId)
-			throw new Error(`An internal graphics element with name '${elementId.name}' already exists.`)
+			throw new Error(`An internal graphics element with name '${elementId.instanceName}' already exists.`)
 		} catch (err) {
 			if (err.message.startsWith('An internal graphics element')) throw err
 		}
@@ -160,7 +160,7 @@ export class Rundown implements VRundown {
 			fielddef = (template as any).model_xml.model.schema[0].fielddef
 		} else {
 			throw new Error(
-				`Could not retrieve field definitions for tempalte '${templateName}'. Not creating element '${elementId.name}'.`
+				`Could not retrieve field definitions for tempalte '${templateName}'. Not creating element '${elementId.instanceName}'.`
 			)
 		}
 		let fieldNames: string[] = fielddef ? fielddef.map((x: any): string => x.$.name) : []
@@ -178,9 +178,9 @@ export class Rundown implements VRundown {
 		}
 		const vizProgram = channel ? ` viz_program="${channel}"` : ''
 		await this.pep.insert(
-			`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`,
+			`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`,
 			`<element name="${
-				elementId.name
+				elementId.instanceName
 			}" guid="${uuid.v4()}" updated="${new Date().toISOString()}" creator="${creatorName}" ${vizProgram}>
 <ref name="master_template">/storage/shows/{${elementId.showId}}/mastertemplates/${templateName}</ref>
 <entry name="default_alternatives"/>
@@ -191,7 +191,7 @@ ${entries}
 			LocationType.Last
 		)
 		return {
-			name: elementId.name,
+			name: elementId.instanceName,
 			template: templateName,
 			data,
 			channel,
@@ -234,7 +234,7 @@ ${entries}
 		const elementNames: Array<InternalElementId> = Object.keys(flatShowElements)
 			.filter((x) => x !== 'name')
 			.map((element) => ({
-				name: element,
+				instanceName: element,
 				showId,
 			}))
 		return elementNames
@@ -284,7 +284,7 @@ ${entries}
 
 	async deleteElement(elementId: ElementId): Promise<PepResponse> {
 		if (isInternalElement(elementId)) {
-			return this.pep.delete(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
+			return this.pep.delete(`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`)
 		} else {
 			// Note: For some reason, in contrast to the other commands, the delete command only works with the path being unescaped:
 			const path = this.getExternalElementPath(elementId, true)
@@ -298,7 +298,7 @@ ${entries}
 
 	async cue(elementId: ElementId): Promise<CommandResult> {
 		if (isInternalElement(elementId)) {
-			return this.msehttp.cue(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
+			return this.msehttp.cue(`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`)
 		} else {
 			const path = this.getExternalElementPath(elementId)
 			if (await this.buildChannelMap(elementId)) {
@@ -315,7 +315,7 @@ ${entries}
 
 	async take(elementId: ElementId): Promise<CommandResult> {
 		if (isInternalElement(elementId)) {
-			return this.msehttp.take(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
+			return this.msehttp.take(`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`)
 		} else {
 			const path = this.getExternalElementPath(elementId)
 			if (await this.buildChannelMap(elementId)) {
@@ -332,7 +332,7 @@ ${entries}
 
 	async continue(elementId: ElementId): Promise<CommandResult> {
 		if (isInternalElement(elementId)) {
-			return this.msehttp.continue(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
+			return this.msehttp.continue(`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`)
 		} else {
 			const path = this.getExternalElementPath(elementId)
 			if (await this.buildChannelMap(elementId)) {
@@ -349,7 +349,7 @@ ${entries}
 
 	async continueReverse(elementId: ElementId): Promise<CommandResult> {
 		if (isInternalElement(elementId)) {
-			return this.msehttp.continueReverse(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
+			return this.msehttp.continueReverse(`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`)
 		} else {
 			const path = this.getExternalElementPath(elementId)
 			if (await this.buildChannelMap(elementId)) {
@@ -366,7 +366,7 @@ ${entries}
 
 	async out(elementId: ElementId): Promise<CommandResult> {
 		if (isInternalElement(elementId)) {
-			return this.msehttp.out(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
+			return this.msehttp.out(`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`)
 		} else {
 			const path = this.getExternalElementPath(elementId)
 			if (await this.buildChannelMap(elementId)) {
@@ -459,9 +459,9 @@ ${entries}
 				return element as ExternalElement
 			}
 		} else {
-			const element = await this.pep.getJS(`/storage/shows/{${elementId.showId}}/elements/${elementId.name}`)
-			const flatElement: FlatEntry = (await flattenEntry(element.js as AtomEntry))[elementId.name] as FlatEntry
-			flatElement.name = elementId.name
+			const element = await this.pep.getJS(`/storage/shows/{${elementId.showId}}/elements/${elementId.instanceName}`)
+			const flatElement: FlatEntry = (await flattenEntry(element.js as AtomEntry))[elementId.instanceName] as FlatEntry
+			flatElement.name = elementId.instanceName
 			return flatElement as InternalElement
 		}
 	}

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,3 +4,7 @@ export function wrapInBracesIfNeeded(value: string): string {
 	}
 	return value
 }
+
+export function has(object: Record<string | number, any>, property: string | number): boolean {
+	return Object.prototype.hasOwnProperty.call(object, property)
+}

--- a/src/v-connection.ts
+++ b/src/v-connection.ts
@@ -121,6 +121,11 @@ export interface InternalElementId {
 	showId: string
 }
 
+export interface InternalElementIdWithCreator extends InternalElementId {
+	/** Who created the element */
+	creator?: string
+}
+
 /** Object uniquely identifying an external element loaded into an Engine */
 export interface ExternalElementId {
 	/** Unique identifier for the template in the external system. */
@@ -295,11 +300,25 @@ export interface VRundown {
 	 */
 	cleanupShow(showId: string): Promise<CommandResult>
 	/**
-	 *  Clear up all graphical elements and state associated with a rundown,
+	 *  Clear up all Internal Elements and state associated with given shows,
 	 *  including those required for post-rundown analysis.
+	 *  @param showIds Names (UUIDs) of the shows to purge.
+	 *	@param onlyCreatedByUs Restricted to removing only elements that have a matching creator attribute
+	 *  @param elementsToKeep Elements to omit from deleting.
 	 *  @result Resolves on successful rundown purge.
 	 */
-	purge(showIds: string[], elementsToKeep?: ElementId[]): Promise<PepResponse>
+	purgeInternalElements(
+		showIds: string[],
+		onlyCreatedByUs?: boolean,
+		elementsToKeep?: InternalElementId[]
+	): Promise<PepResponse>
+	/**
+	 *  Clear up all External Elements and state associated with a rundown,
+	 *  including those required for post-rundown analysis.
+	 *  @param elementsToKeep Elements to omit from deleting.
+	 *  @result Resolves on successful rundown purge.
+	 */
+	purgeExternalElements(elementsToKeep?: ExternalElementId[]): Promise<PepResponse>
 	/**
 	 *  Is the associated MSE playlist currently active?
 	 *  @returns Resolves with the activation status of the associated MSE playlist.

--- a/src/v-connection.ts
+++ b/src/v-connection.ts
@@ -113,6 +113,14 @@ export interface ExternalElement extends VElement {
 	name?: string
 }
 
+/** Object uniquely identifying an internal element loaded into an Engine */
+export interface InternalElementId {
+	/** Unique identifier for the template in its show */
+	name: string
+	/** Show in which the element exists */
+	showId: string
+}
+
 /** Object uniquely identifying an external element loaded into an Engine */
 export interface ExternalElementId {
 	/** Unique identifier for the template in the external system. */
@@ -121,6 +129,16 @@ export interface ExternalElementId {
 	 *  Note when `undefined`, the default is the _program_ channel.
 	 */
 	channel?: string
+}
+
+export type ElementId = InternalElementId | ExternalElementId
+
+export function isInternalElement(elementId: ElementId): elementId is InternalElementId {
+	return (elementId as InternalElementId).name !== undefined
+}
+
+export function isExternalElement(elementId: ElementId): elementId is ExternalElementId {
+	return (elementId as ExternalElementId).vcpid !== undefined
 }
 
 /**
@@ -132,8 +150,6 @@ export interface ExternalElementId {
  *  alias can be used to send that command.
  */
 export interface VRundown {
-	/** Identifier for the show containing the [[VTemplate|master templates]] associated with this rundown. */
-	readonly show: string
 	/** Identifier for the playlist built specifically for this rundown. */
 	readonly playlist: string
 	/** Identifier for the profile that is the targer for commands, the link to the Viz Engines being. */
@@ -141,93 +157,89 @@ export interface VRundown {
 	/** Optional description of the rundown. Used as a name for the playlist in Viz Content Pilot. */
 	readonly description?: string
 	/**
-	 *  List all the master templates associated with this rundown.
+	 *  List all the master templates associated with the given show.
+	 *  @param showId Name of the show.
 	 *  @returns Resolves to a list of all template names for this rundown.
 	 */
-	listTemplates(): Promise<string[]>
+	listTemplates(showId: string): Promise<string[]>
 	/**
 	 *  Read details of a specific [[VTemplate|template]].
-	 *  @param templateName Name of the emplate to retrieve the elements from,
+	 *  @param templateName Name of the emplate to retrieve the details for,
 	 *                      e.g. `bund`.
+	 *  @param showId     Name of the show to retrieve the template from.
 	 *  @returns Resolves to the details of the named template.
 	 */
-	getTemplate(templateName: string): Promise<VTemplate>
+	getTemplate(templateName: string, showId: string): Promise<VTemplate>
 	/**
 	 *  Create a new [[InternalElement|_internal_ graphical element]] that is an
 	 *  instance of the named [[VTemplate|template]].
+	 *  @param elementId Object uniquely identifying an internal or external element.
 	 *  @param templateName Name of the template the element is an instance of.
-	 *  @param elementName  Name of the graphical element to create.
 	 *  @param textFields   List of values for each of the graphical elements.
 	 *  @param channel      Optional channel to play out this graphic. Default is the _program_.
 	 *  @returns Resolves to a newly created element.
 	 */
 	createElement(
+		elementId: InternalElementId,
 		templateName: string,
-		elementName: string,
 		textFields: string[],
 		channel?: string
 	): Promise<InternalElement>
 	/**
 	 *  Create a new [[ExternalElement|_external_ graphical element]] by unique reference number.
-	 *  @param vcpid Unique reference number for the element in the external source,
-	 *               e.g. a pilot database.
-	 *  @param alias Optional name to use to reference the element. Note that this
-	 *               name is stored only within the library and not persisted in
-	 *               the MSE.
-	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
+	 *  @param elementId Object uniquely identifying an external element.
 	 *  @returns Resolves to a newly created element reference.
 	 */
-	createElement(vcpid: number, channel?: string, alias?: string): Promise<ExternalElement>
+	createElement(elementId: ExternalElementId): Promise<ExternalElement>
 	/**
-	 *  List all the graphical elements created for this rundown.
-	 *  @returns Resolves to a list of graphical element names or references for this rundown.
+	 *  List all the internal graphical elements created for a given show.
+	 *  @param showId Name of the show to query, a UUID.
+	 *  @returns Resolves to a list of internal graphical element references.
 	 */
-	listElements(): Promise<Array<string | ExternalElementId>>
+	listInternalElements(showId: string): Promise<Array<InternalElementId>>
+	/**
+	 *  List all the external graphical elements created for this rundown.
+	 *  @returns Resolves to a list of external graphical element ids.
+	 */
+	listExternalElements(): Promise<Array<ExternalElementId>>
 	/**
 	 *  Read the details of a graphical element in this rundown.
-	 *  @param elementName Name or reference (vcpid) for the element to retrieve the details
-	 *                     for.
-	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
+	 *  @param elementId Object uniquely identifying an internal or external element.
 	 *  @returns Resolves to provide the details of the named element.
 	 */
-	getElement(elementName: string | number, channel?: string): Promise<VElement>
+	getElement(elementId: ElementId): Promise<VElement>
 	/**
 	 *  Delete a graphical element from the rundown.
-	 *  @param elementName Name or reference (vcpid) for the element to delete.
-	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
+	 *  @param elementId Object uniquely identifying an internal or external element.
 	 *  @returns Resolves to indicate the delete was successful, otherwise rejects.
 	 */
-	deleteElement(elementName: string | number, channel?: string): Promise<PepResponse>
+	deleteElement(elementId: ElementId): Promise<PepResponse>
 	/**
-	 *  Send a _cue_ command for a named graphical element, preparing it for smooth display.
-	 *  @param elementName Name or reference (vcpid) for the gephical element to cue.
-	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
+	 *  Send a _cue_ command for a graphical element, preparing it for smooth display.
+	 *  @param elementId Object uniquely identifying an internal or external element.
 	 *  @returns Resolves on acceptance of the cue command.
 	 */
-	cue(elementName: string | number, channel?: string): Promise<CommandResult>
+	cue(elementId: ElementId): Promise<CommandResult>
 	/**
-	 *  Send a _take_ command for a named graphical element, requesting that it is displayed.
-	 *  @param elementName Name or reference (vcpid) for the gephical element to take in.
-	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
+	 *  Send a _take_ command for a graphical element, requesting that it is displayed.
+	 *  @param elementId Object uniquely identifying an internal or external element.
 	 *  @returns Resolves on acceptance of the take command.
 	 */
-	take(elementName: string | number, channel?: string): Promise<CommandResult>
+	take(elementId: ElementId): Promise<CommandResult>
 	/**
-	 *  Send a _continue_ command for a named graphical element, causing the next
-	 *  presentation state is to be displayed.
-	 *  @param elementName Name or reference (vcpid) for the gephical element to continue.
-	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
+	 *  Send a _continue_ command for a graphical element, causing the next presentation
+	 *  state to be displayed.
+	 *  @param elementId Object uniquely identifying an internal or external element.
 	 *  @returns Resolves on acceptance of the continue command.
 	 */
-	continue(elementName: string | number, channel?: string): Promise<CommandResult>
+	continue(elementId: ElementId): Promise<CommandResult>
 	/**
-	 *  Send a _continue-reverse_ command for a named graphical element, causing the
+	 *  Send a _continue-reverse_ command for a graphical element, causing the
 	 *  previous presentation state is to be displayed.
-	 *  @param elementName Name or reference (vcpid) for the gephical element to continue.
-	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
+	 *  @param elementId Object uniquely identifying an internal or external element.
 	 *  @returns Resolves on acceptance of the continue command.
 	 */
-	continueReverse(elementName: string | number, channel?: string): Promise<CommandResult>
+	continueReverse(elementId: ElementId): Promise<CommandResult>
 	/**
 	 *  Send an _out_ command for the named graphical element, ending its ongoing
 	 *  display.
@@ -235,7 +247,7 @@ export interface VRundown {
 	 *  @param channel Optional channel to play out this graphic. Default is the _program_.
 	 *  @return Resolves on acceptance of the take-out command.
 	 */
-	out(elementName: string | number, channel?: string): Promise<CommandResult>
+	out(elementId: ElementId): Promise<CommandResult>
 	/**
 	 *  Run the initiaization of an external graphic element. This will cause the
 	 *  element to load all necessary resources onto the assiciated VizEngine ready
@@ -246,7 +258,7 @@ export interface VRundown {
 	 *  @returns Resolves on acceptance of the initialize command. Note that this
 	 *           is not when the element finishes loading on the VizEngine.
 	 */
-	initialize(vcpid: number, channel?: string): Promise<CommandResult>
+	initialize(elementId: ExternalElementId): Promise<CommandResult>
 	/**
 	 *  Activate a rundown, causing all initialisations to be requested prior to
 	 *  the execution of a rundown. Note that experimentation has shown that it
@@ -254,14 +266,12 @@ export interface VRundown {
 	 *  apart.
 	 *  @param twice        Trigger the activations twice, which may cause
 	 *                      graphical elements to start loading.
-	 *  @param initShow     Initialize the show containing internal elements. This
-	 *                      defaults to `true`.
 	 *  @param initPlaylist Initialize the playlist containing external elements.
 	 *                      This defaults to `true`.
 	 *  @returns Resolves on successful rundown activation. Rejects if any step
 	 *           fails.
 	 */
-	activate(twice?: boolean, initShow?: boolean, initPlaylist?: boolean): Promise<CommandResult>
+	activate(twice?: boolean, initPlaylist?: boolean): Promise<CommandResult>
 	/**
 	 *  Deactivate a rundown, cleaning up any transient elements associated with
 	 *  the rundown from the VDOM tree. Those XML elements required for post-rundown
@@ -271,18 +281,25 @@ export interface VRundown {
 	 */
 	deactivate(cleanupShow?: boolean): Promise<CommandResult>
 	/**
+	 *  Start loading templates and Internal Elements of the show to the Engines.
+	 *  @param showId Name (UUID) of the show.
+	 *  @returns Resolves on a successful request to initialize.
+	 */
+	initializeShow(showId: string): Promise<CommandResult>
+	/**
 	 *  Cleanup the show and all associated renderers. This may be necessary if the
 	 *  state of the VizEngine is in a bad or in some way out of step with the automation
 	 *  system.
+	 *  @param showId Name (UUID) of the show.
 	 *  @returns Resolves on a successful request to cleanup.
 	 */
-	cleanup(): Promise<CommandResult>
+	cleanupShow(showId: string): Promise<CommandResult>
 	/**
 	 *  Clear up all graphical elements and state associated with a rundown,
 	 *  including those required for post-rundown analysis.
 	 *  @result Resolves on successful rundown purge.
 	 */
-	purge(elementsToKeep?: ExternalElementId[]): Promise<PepResponse>
+	purge(showIds: string[], elementsToKeep?: ElementId[]): Promise<PepResponse>
 	/**
 	 *  Is the associated MSE playlist currently active?
 	 *  @returns Resolves with the activation status of the associated MSE playlist.
@@ -410,10 +427,10 @@ export interface MSE extends EventEmitter {
 	listShows(): Promise<string[]>
 	/**
 	 *  Retrieve details of a specific show as stored at this MSE.
-	 *  @param showName Name of the show to query, a UUID.
+	 *  @param showId Name of the show to query, a UUID.
 	 *  @returns Resolves to the details of the named show.
 	 */
-	getShow(showName: string): Promise<VShow>
+	getShow(showId: string): Promise<VShow>
 	/**
 	 *  List the playlists stored for this MSE.
 	 *  @returns Resolves to a list of playlists stored for this MSE.
@@ -427,7 +444,6 @@ export interface MSE extends EventEmitter {
 	getPlaylist(playlistName: string): Promise<VPlaylist>
 	/**
 	 *  Create a new rundown to be executed on this MSE.
-	 *  @param showID       Identifier of the show to create.
 	 *  @param profileName  Name of the profile to send commands to.
 	 *  @param playlistID   Optional UUID identifier for the playlist. If none is
 	 *                      provided, one will be generated.
@@ -435,7 +451,7 @@ export interface MSE extends EventEmitter {
 	 *                      Content Pilot.
 	 *  @return Resolves to a newly created rundown.
 	 */
-	createRundown(showID: string, profile: string, playlistID?: string, description?: string): Promise<VRundown>
+	createRundown(profile: string, playlistID?: string, description?: string): Promise<VRundown>
 	/**
 	 *  Delete a rundown from this MSE. Note that rundowns can only be deleted when
 	 *  they are not activated.

--- a/src/v-connection.ts
+++ b/src/v-connection.ts
@@ -116,7 +116,7 @@ export interface ExternalElement extends VElement {
 /** Object uniquely identifying an internal element loaded into an Engine */
 export interface InternalElementId {
 	/** Unique identifier for the template in its show */
-	name: string
+	instanceName: string
 	/** Show in which the element exists */
 	showId: string
 }
@@ -134,7 +134,7 @@ export interface ExternalElementId {
 export type ElementId = InternalElementId | ExternalElementId
 
 export function isInternalElement(elementId: ElementId): elementId is InternalElementId {
-	return (elementId as InternalElementId).name !== undefined
+	return (elementId as InternalElementId).instanceName !== undefined
 }
 
 export function isExternalElement(elementId: ElementId): elementId is ExternalElementId {


### PR DESCRIPTION
BREAKING CHANGES: various API changes due to the Rundown no longer being restricted to using a single Show. To support controlling elements across multiple shows at the same time, the `showId` (previously also known as `showName`) has to be provided for each internal element, as a property of the InternalElementId.