### PR TITLE
fix: (SOF-970) solved errors from eslint/prettier VS Code extension.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,9 @@
 {
-	"extends": "./node_modules/@sofie-automation/code-standard-preset/eslint/main"
+	"extends": "./node_modules/@sofie-automation/code-standard-preset/eslint/main",
+	"prettier/prettier": [
+		"error",
+		{
+			"endOfLine": "auto"
+		}
+	]
 }


### PR DESCRIPTION
- Fixed end of line error, that arose when i installed https://prettier.io/ on my VS Code. Should solve it for others that also installs that extension, in the future.

Didn't end up needing any change for logging (yet), as the logs in questions was done with error level, which is OK. The amount of error logs was/is excessive, which is the reason i took a look, and why it might need to be looked at further in the future.