### PR TITLE
SOF-1140 discard extra template fields instead of throwing

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -51,6 +51,9 @@ jobs:
           name: dist artifacts
           path: dist
 
+      - name: yarn install
+        run: yarn install
+
       - uses: JS-DevTools/npm-publish@v1
         with:
           access: public

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -56,7 +56,7 @@ export class Rundown implements VRundown {
 			this.mse.restPort
 		)
 		this.initialChannelMapPromise = this.buildChannelMap().catch((err) =>
-			console.error(`Warning: Failed to build channel map: ${err.message}`)
+			this.mse.emit('warning', `Failed to build channel map: ${err.message}`)
 		)
 	}
 
@@ -162,21 +162,22 @@ export class Rundown implements VRundown {
 			fielddef = (template as any).model_xml.model.schema[0].fielddef
 		} else {
 			throw new Error(
-				`Could not retrieve field definitions for tempalte '${templateName}'. Not creating element '${elementId.instanceName}'.`
+				`Could not retrieve field definitions for template '${templateName}'. Not creating element '${elementId.instanceName}'.`
 			)
 		}
 		let fieldNames: string[] = fielddef ? fielddef.map((x: any): string => x.$.name) : []
 		let entries = ''
 		const data: { [name: string]: string } = {}
 		if (textFields.length > fieldNames.length) {
-			throw new Error(
+			this.mse.emit(
+				'warning',
 				`For template '${templateName}' with ${fieldNames.length} field(s), ${textFields.length} fields have been provided.`
 			)
 		}
 		fieldNames = fieldNames.sort()
 		for (let x = 0; x < fieldNames.length; x++) {
-			entries += `    <entry name="${fieldNames[x]}">${textFields[x] ? textFields[x] : ''}</entry>\n`
-			data[fieldNames[x]] = textFields[x] ? textFields[x] : ''
+			entries += `    <entry name="${fieldNames[x]}">${textFields[x] ?? ''}</entry>\n`
+			data[fieldNames[x]] = textFields[x] ?? ''
 		}
 		const vizProgram = channel ? ` viz_program="${channel}"` : ''
 		await this.pep.insert(
@@ -222,7 +223,7 @@ ${entries}
 		try {
 			await this.initialChannelMapPromise
 		} catch (err) {
-			console.error(`Warning: createElement: Channel map not built: ${getPepErrorMessage(err)}`)
+			this.mse.emit('warning', `createElement: Channel map not built: ${getPepErrorMessage(err)}`)
 		}
 	}
 

--- a/src/v-connection.ts
+++ b/src/v-connection.ts
@@ -523,6 +523,7 @@ export interface MSE extends EventEmitter {
 	// Add methods here for MSE configuration
 	/** Add a listener for all non-error messages and events from the server. */
 	on(event: 'connected', listener: () => void): this
+	on(event: 'warning', listener: (message: string) => void): this
 	/** Add a listener for all error messages from the server. */
 	on(event: 'disconnected', listener: (err?: Error) => void): this
 }


### PR DESCRIPTION
When more fields are provided than the mastertemplate supports, reject the excessive fields and create the element(emitting a warning) instead of throwing.
For that, it adds a new event type.
Also fixes the workflow to make npm publishing work again.