### PR TITLE
Sof 1094/automate maintenance mse playlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"build": "rimraf dist && yarn build:main",
 		"buildtest": "yarn build && jest",
 		"build:main": "tsc -p tsconfig.build.json",
-		"lint": "eslint . --ext .ts --ext .js --ext .tsx --ext .jsx --ignore-pattern dist",
+		"lint": "eslint . --ext .ts --ext .js --ext .tsx --ext .jsx --ignore-pattern dist --ignore-pattern docs",
 		"lint-fix": "yarn lint --fix",
 		"unitci": "jest",
 		"unit": "jest",

--- a/src/mse.ts
+++ b/src/mse.ts
@@ -179,18 +179,18 @@ export class MSERep extends EventEmitter implements MSE {
 
 	// Rundown basics task
 	async createRundown(profileName: string, playlistID?: string, description?: string): Promise<VRundown> {
-		await this.assertProfileExistsForName(profileName)
+		await this.assertProfileExists(profileName)
 
 		description = description ? description : `Sofie Rundown ${new Date().toISOString()}`
 		playlistID = playlistID ? playlistID.toUpperCase() : uuid.v4().toUpperCase()
 
-		if (!(await this.doPlaylistExistForPlaylistId(playlistID, profileName))) {
+		if (!(await this.doesPlaylistExist(playlistID, profileName))) {
 			await this.createNewPlaylist(playlistID, description, profileName)
 		}
 		return new Rundown(this, profileName, playlistID, description)
 	}
 
-	private async assertProfileExistsForName(profileName: string): Promise<void> {
+	private async assertProfileExists(profileName: string): Promise<void> {
 		try {
 			await this.pep.get(`/config/profiles/${profileName}`, 1)
 		} catch (err) {
@@ -200,7 +200,7 @@ export class MSERep extends EventEmitter implements MSE {
 		}
 	}
 
-	private async doPlaylistExistForPlaylistId(playlistID: string, profileName: string): Promise<boolean> {
+	private async doesPlaylistExist(playlistID: string, profileName: string): Promise<boolean> {
 		try {
 			const playlist = await this.getPlaylist(playlistID.toUpperCase())
 			if (!playlist.profile.endsWith(`/${profileName}`)) {

--- a/src/mse.ts
+++ b/src/mse.ts
@@ -210,18 +210,14 @@ export class MSERep extends EventEmitter implements MSE {
 	}
 
 	private async doesPlaylistExist(playlistID: string, profileName: string): Promise<boolean> {
-		try {
-			const playlist = await this.getPlaylist(playlistID.toUpperCase())
-			if (!playlist.profile.endsWith(`/${profileName}`)) {
-				throw new Error(
-					`Referenced playlist exists but references profile '${playlist.profile}' rather than the given '${profileName}'.`
-				)
-			}
-		} catch (err) {
-			if (getPepErrorMessage(err).startsWith('Referenced playlist exists but')) {
-				throw err
-			}
+		const playlist = await this.getPlaylist(playlistID.toUpperCase())
+		if (!playlist) {
 			return false
+		}
+		if (!playlist.profile.endsWith(`/${profileName}`)) {
+			throw new Error(
+				`Referenced playlist exists but references profile '${playlist.profile}' rather than the given '${profileName}'.`
+			)
 		}
 		return true
 	}


### PR DESCRIPTION
PlaylistID is no longer required to be a UUID. If no PlaylistID has been provided it still defaults to UUIDs. 

Refactor the `createRundown` method into smaller methods.

Ignoring the `docs` folder when running lint since this is an autogenerated library.
