### PR TITLE
fix: SOF-1094 return false when playlist doesnt exist in doesPlaylistExist

### DIFF
--- a/src/mse.ts
+++ b/src/mse.ts
@@ -210,12 +210,7 @@ export class MSERep extends EventEmitter implements MSE {
 	}
 
 	private async doesPlaylistExist(playlistID: string, profileName: string): Promise<boolean> {
-		let playlist
-		try {
-			playlist = await this.getPlaylist(playlistID.toUpperCase())
-		} catch (error) {
-			return false
-		}
+		const playlist = await this.getPlaylist(playlistID.toUpperCase()).catch(() => undefined)
 		if (!playlist) {
 			return false
 		}

--- a/src/mse.ts
+++ b/src/mse.ts
@@ -210,7 +210,12 @@ export class MSERep extends EventEmitter implements MSE {
 	}
 
 	private async doesPlaylistExist(playlistID: string, profileName: string): Promise<boolean> {
-		const playlist = await this.getPlaylist(playlistID.toUpperCase())
+		let playlist
+		try {
+			playlist = await this.getPlaylist(playlistID.toUpperCase())
+		} catch (error) {
+			return false
+		}
 		if (!playlist) {
 			return false
 		}


### PR DESCRIPTION
An error was being thrown that wasn't caught anymore due to a late refactoring in the PR review process.
Now catches that error and return false as was the original behaviour.