### PR TITLE
Fix/sofie 1968/safer purging

### DIFF
--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -481,20 +481,18 @@ ${entries}
 		return { id: '*', status: 'ok' } as PepResponse
 	}
 
-	async purgeExternalElements(elementsToKeep?: ExternalElementId[]): Promise<PepResponse> {
-		// let playlist = await this.mse.getPlaylist(this.playlist)
-		// if (playlist.active_profile.value) {
-		// 	throw new Error(`Cannot purge an active profile.`)
-		// }
-		if (elementsToKeep && elementsToKeep.length) {
-			await this.buildChannelMap()
-			const elementsSet = new Set(
-				elementsToKeep.map((e) => {
-					return Rundown.makeKey(e)
-				})
-			)
-			for (const key in this.channelMap) {
-				if (elementsSet.has(key)) continue
+	async purgeExternalElements(elementsToKeep: ExternalElementId[] = []): Promise<PepResponse> {
+		await this.buildChannelMap()
+		const elementsSet = new Set(
+			elementsToKeep.map((e) => {
+				return Rundown.makeKey(e)
+			})
+		)
+
+		await Promise.all(
+			Object.keys(this.channelMap).map(async (key) => {
+				if (elementsSet.has(key)) return
+
 				try {
 					await this.deleteElement(this.channelMap[key])
 				} catch (e) {
@@ -502,10 +500,9 @@ ${entries}
 						throw e
 					}
 				}
-			}
-		} else {
-			await this.pep.replace(`/storage/playlists/{${this.playlist}}/elements`, '<elements/>')
-		}
+			})
+		)
+
 		return { id: '*', status: 'ok' } as PepResponse
 	}
 

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -453,18 +453,14 @@ ${entries}
 	async purgeInternalElements(
 		showIds: string[],
 		onlyCreatedByUs?: boolean,
-		elementsToKeep?: InternalElementId[]
+		elementsToKeep: InternalElementId[] = []
 	): Promise<PepResponse> {
 		const elementsToKeepSet = new Set(
-			elementsToKeep?.map((e) => {
+			elementsToKeep.map((e) => {
 				return Rundown.makeKey(e)
 			})
 		)
 		for (const showId of showIds) {
-			if (!onlyCreatedByUs && !elementsToKeep?.length) {
-				await this.pep.replace(`/storage/shows/{${showId}}/elements`, '<elements/>')
-				continue
-			}
 			const elements = await this.listInternalElements(showId)
 			await Promise.all(
 				elements.map(async (element) => {
@@ -472,9 +468,8 @@ ${entries}
 						(!onlyCreatedByUs || element.creator === CREATOR_NAME) &&
 						!elementsToKeepSet.has(Rundown.makeKey(element))
 					) {
-						return this.deleteElement(element)
+						await this.deleteElement(element)
 					}
-					return Promise.resolve()
 				})
 			)
 		}

--- a/src/rundown.ts
+++ b/src/rundown.ts
@@ -484,7 +484,7 @@ ${entries}
 			})
 		)
 
-		await Promise.all(
+		const ps = [
 			Object.keys(this.channelMap).map(async (key) => {
 				if (elementsSet.has(key)) return
 
@@ -495,8 +495,10 @@ ${entries}
 						throw e
 					}
 				}
-			})
-		)
+			}),
+		]
+		await Promise.allSettled(ps) // Wait for all Promises
+		await Promise.all(ps) // throw if there are any rejected Promises
 
 		return { id: '*', status: 'ok' } as PepResponse
 	}


### PR DESCRIPTION
We have reason to believe that the `pep.replace()` method is unsafe for nested structures.

This implementation:
* Deletes all child elements one by one
* Changes the deletion of external elements from awaiting each operation to handle all in a `Promise.all()` to speed up the operation. If this causes regressions/problems, we will change and fall back to awaiting each delete-operation.

**NRK only uses External elements!** Changes to the handling of internal elements is a blind implementation and will remain untested even when submitting the PR!