### PR TITLE
fix: treat "inexist" error as InexistentError

### DIFF
--- a/src/__tests__/peptalk.spec.ts
+++ b/src/__tests__/peptalk.spec.ts
@@ -375,6 +375,9 @@ describe('PepTalk with sadness', () => {
 	test('Get inexistent', async () => {
 		await expect(pep.get('/mockError/inexistent', 3)).rejects.toThrow(InexistentError)
 	})
+	test('Get inexist', async () => {
+		await expect(pep.get('/mockError/inexist', 3)).rejects.toThrow(InexistentError)
+	})
 
 	test('Get invalid', async () => {
 		await expect(pep.get('/mockError/invalid', 3)).rejects.toThrow(InvalidError)

--- a/src/peptalk.ts
+++ b/src/peptalk.ts
@@ -486,6 +486,7 @@ class PepTalk extends EventEmitter implements PepTalkClient, PepTalkJS {
 			endOfErrorName = endOfErrorName > errorIndex + 6 ? endOfErrorName : m.length
 			switch (m.slice(errorIndex + 6, endOfErrorName)) {
 				case 'inexistent':
+				case 'inexist':
 					error = new InexistentError(c, m.slice(endOfErrorName + 1), pending.sent)
 					break
 				case 'invalid':


### PR DESCRIPTION
I experienced the error `Error: PepTalk inexist error for request 755644: 755644 error inexist`, which wasn't handled properly and instead was emitted as an error event.

This PR adds a case to handle the error the same way we handle the previously known `"inexistent"` error.

