### PR TITLE
Update GitHub Actions to use v4

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -11,9 +11,9 @@ jobs:
   run-yarn-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -27,13 +27,13 @@ jobs:
       - name: yarn build
         run: yarn build
 
-      - name: yarn unit test 
+      - name: yarn unit test
         run: yarn unit
 
       - name: yarn install production
         run: yarn install --check-files --frozen-lockfile --production --force
 
-      - uses: actions/upload-artifact@main
+      - uses: actions/upload-artifact@v4
         with:
           name: dist artifacts
           path: dist
@@ -44,9 +44,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        
-      - uses: actions/download-artifact@v2
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
         with:
           name: dist artifacts
           path: dist


### PR DESCRIPTION
Update GitHub Actions to use v4.
No longer use `main` for upload so all the Actions are using the same version.